### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "license": "ISC",
   "repository": "https://github.com/christophehurpeau/rollup-plugin-svgr.git",
   "homepage": "https://github.com/christophehurpeau/rollup-plugin-svgr",
+  "bugs": {
+    "url": "https://github.com/christophehurpeau/rollup-plugin-svgr/issues"
+  },
   "type": "module",
   "packageManager": "yarn@4.11.0",
   "engines": {


### PR DESCRIPTION
## Summary

- add `bugs.url` metadata to the package manifest
- point npm users to the GitHub issue tracker for support and bug reports

## Verification

- `node -e "const p=require('./package.json'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage,license:p.license}, null, 2)); if (p.bugs?.url !== 'https://github.com/christophehurpeau/rollup-plugin-svgr/issues') process.exit(1)"`
- `git diff --check`
- `npm pack --dry-run --json`

This is an AI-assisted metadata cleanup.
